### PR TITLE
Content/relative clauses

### DIFF
--- a/src/componentes/poliglota/Listas/intermediate-grammar/11-relative-clauses/90-relative-clauses-1.js
+++ b/src/componentes/poliglota/Listas/intermediate-grammar/11-relative-clauses/90-relative-clauses-1.js
@@ -1,0 +1,19 @@
+// 90 Relative Clauses 1: Clauses with who/that/which
+
+const relativeClausesOne = [
+    ['The woman who lives next door … 👩‍🦰🏠', 'La mujer que vive al lado… 👩‍🦰🏠'],
+    ['People who live in the country… 👨‍🌾🌳', 'Las personas que viven en el campo… 👨‍🌾🌳'],
+    ['An architect is someone who designs buildings. 👷‍♂️🏗️', 'Un arquitecto es alguien que diseña edificios. 👷‍♂️🏗️'],
+    ['What was the name of the person who called you? 📞👤', '¿Cuál era el nombre de la persona que te llamó? 📞👤'],
+    ['Anyone who wants to apply for the job must do so by Friday. 👨‍💼📅', 'Cualquiera que quiera solicitar el trabajo debe hacerlo antes del viernes. 👨‍💼📅'],
+    ['The woman who lives next door is a doctor. 👩‍⚕️💼', 'La mujer que vive al lado es doctora. 👩‍⚕️💼'],
+    ["I don’t like stories that have unhappy endings. 📖😔", "No me gustan las historias que tienen finales infelices. 📖😔"],
+    ['Barbara works for a company that makes furniture. 👩‍💼🪑', 'Barbara trabaja para una empresa que fabrica muebles. 👩‍💼🪑'],
+    ['The machine that broke down is working again now. 🛠️🔧', 'La máquina que se descompuso ahora está funcionando de nuevo. 🛠️🔧'],
+    ['What happened was my fault. 🤷‍♂️🚫', 'Lo que pasó fue mi culpa. 🤷‍♂️🚫'],
+    ['Everything that happened was my fault. 🔄🚫', 'Todo lo que pasó fue mi culpa. 🔄🚫'],
+    ['The machine that broke down is now working again. 🛠️🔄', 'La máquina que se descompuso ahora está funcionando de nuevo. 🛠️🔄'],
+    ["I’ve never spoken to the woman who lives next door. 🤐👩‍🦰", "Nunca he hablado con la mujer que vive al lado. 🤐👩‍🦰"],
+  ];
+  
+export default relativeClausesOne;

--- a/src/componentes/poliglota/Listas/intermediate-grammar/11-relative-clauses/91-relative-clauses-2.js
+++ b/src/componentes/poliglota/Listas/intermediate-grammar/11-relative-clauses/91-relative-clauses-2.js
@@ -1,0 +1,23 @@
+// 91 Relative Clauses 2: Clauses with and without who/that/which
+
+const relativeClausesTwo = [
+    ['Where is the cheese that was in the refrigerator? 🧀❓', '¿Dónde está el queso que estaba en el refrigerador? 🧀❓'],
+    ['The woman who I wanted to see was away on vacation. 👩‍🦰✈️', 'La mujer a quien quería ver estaba de vacaciones. 👩‍🦰✈️'],
+    ['Have you found the keys that you lost? 🔑🔍', '¿Has encontrado las llaves que perdiste? 🔑🔍'],
+    ['The woman I wanted to see was away. 👩‍🦰🏖️', 'La mujer que quería ver estaba fuera. 👩‍🦰🏖️'],
+    ['Have found the keys you lost? 🔑🔍', '¿Has encontrado las llaves que perdiste? 🔑🔍'],
+    ['The dress Ann bought doesn’t fit her very well. 👗🤔', 'El vestido que Ann compró no le queda muy bien. 👗🤔'],
+    ['Is there anything I can do? 🤷‍♂️💼', '¿Hay algo que pueda hacer? 🤷‍♂️💼'],
+    ['Tom is talking to a woman –Do you know her? 👨‍💼👩', 'Tom está hablando con una mujer. ¿La conoces? 👨‍💼👩'],
+    ['Do you know the woman Tom is talking to? 👩👨‍💼', '¿Conoces a la mujer con la que está hablando Tom? 👩👨‍💼'],
+    ['I slept in a bed last night. It wasn’t very comfortable. 🛏️😴', 'Dormí en una cama anoche. No fue muy cómodo. 🛏️😴'],
+    ['The bed I slept in last night wasn’t very comfortable. 🛏️😔', 'La cama en la que dormí anoche no fue muy cómoda. 🛏️😔'],
+    ['Are these the books you were looking for? 📚🔍', '¿Estos son los libros que estabas buscando? 📚🔍'],
+    ['The woman he fell in love with left him after a month. 💔👩', 'La mujer de quien se enamoró lo dejó después de un mes. 💔👩'],
+    ['The man I was sitting next to on the plane talked all the time. ✈️🗣️', 'El hombre con quien estaba sentado en el avión hablaba todo el tiempo. ✈️🗣️'],
+    ['Everything that they said was true. 🗣️✅', 'Todo lo que dijeron era cierto. 🗣️✅'],
+    ['I gave her all the money that I had. 💰🤲', 'Le di todo el dinero que tenía. 💰🤲'],
+    ['Did you hear what they said? 👂🤔', '¿Oíste lo que dijeron? 👂🤔'],
+  ];  
+
+export default relativeClausesTwo;

--- a/src/componentes/poliglota/Listas/intermediate-grammar/11-relative-clauses/92-relative-clauses-2.js
+++ b/src/componentes/poliglota/Listas/intermediate-grammar/11-relative-clauses/92-relative-clauses-2.js
@@ -1,0 +1,23 @@
+// 92 Relative Clauses 3: Whose/whom/where
+
+const relativeClausesThree = [
+    ['We saw some people whose car had broken down. 🚗😔', 'Vimos a algunas personas cuyo coche se había averiado. 🚗😔'],
+    ['A widow is a woman whose husband is dead. 👩‍⚖️💔', 'Una viuda es una mujer cuyo esposo ha fallecido. 👩‍⚖️💔'],
+    ['What’s the name of the man whose car you borrowed? 🚗👨‍💼', '¿Cuál es el nombre del hombre cuyo coche tomaste prestado? 🚗👨‍💼'],
+    ['I met someone whose brother I went to school with. 👥🏫', 'Conocí a alguien cuyo hermano fue compañero de escuela mío. 👥🏫'],
+    ['I met a man who knows you. 👨‍🦱👋', 'Conocí a un hombre que te conoce. 👨‍🦱👋'],
+    ['I met a man whose sister knows you. 👨‍🦱👩‍🦱👋', 'Conocí a un hombre cuya hermana te conoce. 👨‍🦱👩‍🦱👋'],
+    ['The woman whom I wanted to see was away on vacation. 👩🏖️', 'La mujer a quien quería ver estaba de vacaciones. 👩🏖️'],
+    ['The people with whom I work are very nice. 👥👩‍💼', 'Las personas con quienes trabajo son muy amables. 👥👩‍💼'],
+    ['The woman I wanted to see. 👩👀', 'La mujer que quería ver. 👩👀'],
+    ['The woman who I wanted to see. 👩👀', 'La mujer a quien quería ver. 👩👀'],
+    ['The woman that I wanted to see. 👩👀', 'La mujer que quería ver. 👩👀'],
+    ['I recently went back to the town where I grew up. 🏠👦🔄', 'Recientemente volví al pueblo donde crecí. 🏠👦🔄'],
+    ['I would like to live in a place where there is plenty of sunshine. 🌞🏡', 'Me gustaría vivir en un lugar donde haya mucho sol. 🌞🏡'],
+    ['Do you remember the day that we went to the zoo? 🦁📅', '¿Recuerdas el día que fuimos al zoológico? 🦁📅'],
+    ['The last time that I saw her, she looked fine. 👩‍⚕️🕰️', 'La última vez que la vi, lucía bien. 👩‍⚕️🕰️'],
+    ['I haven’t seen them since the year that they got married. 👰🤵🗓️', 'No los he visto desde el año en que se casaron. 👰🤵🗓️'],
+    ['The reason I’m calling you is to ask your advice. 📞🤔', 'La razón por la que te llamo es para pedirte consejo. 📞🤔'],
+  ];
+  
+export default relativeClausesThree;


### PR DESCRIPTION
# Implemented Changes:

Add sentences related to the following topics:
- 90 Relative Clauses 1: Clauses with who/that/which
-  91 Relative Clauses 2: Clauses with and without who/that//which
-  92 relative Clauses 3: Whose/whom/where


