### PR TITLE
Feat/refactor mid element

### DIFF
--- a/src/componentes/general/ElementoCentral.jsx/MidElement.jsx
+++ b/src/componentes/general/ElementoCentral.jsx/MidElement.jsx
@@ -10,14 +10,6 @@ import Casa from "../../Contextos/Casa"
 import Tiempos from "../Tiempos"
 
 function MidElement() {
-  const [width, setWidth] = useState(window.innerWidth)
-
-  window.addEventListener("resize", () => {
-    setWidth(window.innerWidth)
-  })
-
-  console.log(width)
-
   return (
     <div className="flex flex-col sm:flex-row items-center sm:items-start bg-slate-300 min-h-screen  gap-2 justify-around items-start p-7">
       

--- a/src/componentes/general/ElementoCentral.jsx/MidElement.jsx
+++ b/src/componentes/general/ElementoCentral.jsx/MidElement.jsx
@@ -19,7 +19,7 @@ function MidElement() {
   console.log(width)
 
   return (
-    <div className={`${width < 600 ? "flex-col items-center " : ""} flex bg-slate-300 min-h-screen  gap-2 justify-around items-start p-7`}>
+    <div className="flex flex-col sm:flex-row items-center sm:items-start bg-slate-300 min-h-screen  gap-2 justify-around items-start p-7">
       
       <PreguntayRespuesta/>
 


### PR DESCRIPTION
# Implemented Changes:

On this PL I had to Refactor the responsiveness of the MidElement component to make it simpler, cleaner, and more readable:
-  Re-applied the responsiveness of the element using tailwind CSS only.
- Removed Unnecessary logic like:
    - Ternary operator 
    - the state variable storing the window's width (we don't need it since we can do that with plain CSS or Tailwind-CSS which does the same job with less logic and/or fewer lines of code.)
  
These changes should simplify the component keeping it readable and maintable.
Please take a look and approve if you think this is right @mpa-mxiang @ibugithub @benja27 